### PR TITLE
Adding categories to package export (Datasets or Programs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ build/
 
 ### Environment ###
 .env.development
+.env
 advanced-export.zip

--- a/src/logic/configuration.js
+++ b/src/logic/configuration.js
@@ -38,14 +38,15 @@ export let dependencyRules = [
 export const namespaceName = 'export-metadata-blacklist';
 export let defaultBlacklist = {
     "*": [],
-    "categoryCombo": [
-        "category"
-    ],
+    "categoryCombo": [],
     "categoryOption": [
         "category", "categoryOptionCombo"
     ],
     "categoryOptionCombo": [
         "categoryCombo"
+    ],
+    "category": [
+        "categoryCombo", "categoryOptionCombo"
     ],
     "dataElement": [
         "dataSet"


### PR DESCRIPTION
 - Changing default BlackList for pruning dependency export.
 - CategoryCombo objects do not ignore category relationships.
 - To avoid non-ending loops, category does not further the export to
   categoryOptionCombos nor categoryCombos.